### PR TITLE
Fix rounding tie-breaker rule to be round half away from zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,17 @@ Math::pow(2; 10)		# 1024
 
 # Math::round($decimals)
 1234.567 | Math::round(2)		# 1234.57
+
+# Math::round($decimals)
+-1234.567 | Math::round(2)		# -1234.57
 ```
+
+
+
+## Rounding tie-breaker rule
+
+- Rounding uses the [round half away from zero](https://en.wikipedia.org/wiki/Rounding#Round_half_away_from_zero) tie-breaker rule.
+- Additional rounding tie-breaker rules can be implemented; perhaps in a separate rounding package.
 
 
 

--- a/jq/main.jq
+++ b/jq/main.jq
@@ -7,8 +7,9 @@ def round($decimals):
 	. as $x
 	# Assuming decimal numbers.
 	| 10 as $base
+	| (if $x < 0 then -1 else 1 end) as $signNegator
 	| pow($base; $decimals) as $shifter
-	| $x * $shifter
+	| $x * $shifter * $signNegator
 	| floor as $integer
 	| (
 		if (((. - $integer) * $base | floor) * 2) >= $base then
@@ -18,7 +19,7 @@ def round($decimals):
 		end
 	) as $rounding
 	| $integer + $rounding
-	| . / $shifter;
+	| . / $shifter * $signNegator;
 
 def round:
 	round(0);

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -45,6 +45,21 @@ round/0: rounds up
 round
 11
 
+round/0: rounds half away from zero
+0.5
+round
+1
+
+round/0: rounds half away from zero
+-0.5
+round
+-1
+
+round/0: rounds away from zero
+-10.9
+round
+-11
+
 round/1: rounds up.
 1234.567
 round
@@ -79,6 +94,16 @@ round/1: rounds up for 2
 0.6666
 round(2)
 0.67
+
+round/1: rounds away from zero
+36.475
+round(2)
+36.48
+
+round/1: rounds away from zero
+-36.475
+round(2)
+-36.48
 
 round/1: round down.
 0.123456789


### PR DESCRIPTION
Fix rounding tie-breaker rule to be round half away from zero

- Simple fix: ensure all numbers are positive before rounding, then negating afterwards if the input was negative.
- https://en.wikipedia.org/wiki/Rounding#Round_half_away_from_zero

Closes #1
